### PR TITLE
Use setup-gradle to setup cache when building android apps

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -158,9 +158,11 @@ jobs:
               with:
                 distribution: 'zulu'
                 java-version: 17
-                cache: 'gradle'
 
-            - name: Prepare gradle
+            - name: Setup Gradle
+              uses: gradle/actions/setup-gradle@v3
+
+            - name: Prepare Gradle
               run: |
                 echo "${{ secrets.RELEASE_KEYSTORE }}" > release.keystore.asc
                 gpg -d --passphrase "${{ secrets.RELEASE_PASSWORD }}" --batch release.keystore.asc > keystore/debug.keystore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "animetv",
-    "version": "5.1.4",
+    "version": "5.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "animetv",
-            "version": "5.1.4",
+            "version": "5.2.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "axios": "^1.7.2",
@@ -323,9 +323,9 @@
             "optional": true
         },
         "node_modules/@types/node": {
-            "version": "20.14.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
-            "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+            "version": "20.14.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+            "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
             "devOptional": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
@@ -909,9 +909,9 @@
             }
         },
         "node_modules/electron": {
-            "version": "30.0.6",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.6.tgz",
-            "integrity": "sha512-PkhEPFdpYcTzjAO3gMHZ+map7g2+xCrMDedo/L1i0ir2BRXvAB93IkTJX497U6Srb/09r2cFt+k20VPNVCdw3Q==",
+            "version": "30.1.2",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-30.1.2.tgz",
+            "integrity": "sha512-A5CFGwbA+HSXnzwjc8fP2GIezBcAb0uN/VbNGLOW8DHOYn07rvJ/1bAJECHUUzt5zbfohveG3hpMQiYpbktuDw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -2326,12 +2326,15 @@
             "dev": true
         },
         "node_modules/is-core-module": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+            "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
             "dev": true,
             "dependencies": {
-                "hasown": "^2.0.0"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2640,9 +2643,9 @@
             }
         },
         "node_modules/nan": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.19.0.tgz",
-            "integrity": "sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+            "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
             "dev": true,
             "optional": true
         },


### PR DESCRIPTION
This pulls request contain a fix for the Gradle cache.

Based on previous usage of GitHub Actions, the workflow is unable to download the latest cache uploaded by the previous run. It is noticed that setup-java seems to have limited features when comes to cache. Switching to setup-gradle (first-party actions) should fix the cache loading error. Also, this is also recommended in this issue actions/setup-java#588.

As a side note, this also updates the package-lock.json file. I noticed that you didn't upload the latest package-lock.json causing overhead for the CI to reconfigure the package-lock file every runs.