### PR TITLE
Add subtitle option for outline thickness

### DIFF
--- a/app/src/main/assets/view/m.css
+++ b/app/src/main/assets/view/m.css
@@ -2002,6 +2002,7 @@ c.loader {
    -.1vw .1vw .05vw #000,
    .1vw .1vw .05vw #000,
   0 0 .1vw #000, 0 0 .2vw #000, .1vw .1vw .4vw #000 !important;
+  -webkit-text-stroke-color: #000 !important;
 }
 #vtt_subtitle_preview .vtt_obj,
 #vtt_subtitle .vtt_obj{
@@ -2084,6 +2085,7 @@ c.loader {
    -.1vw .1vw .05vw #fff,
    .1vw .1vw .05vw #fff,
   0 0 .1vw #000, 0 0 .2vw #000, .1vw .1vw .4vw #000 !important;
+  -webkit-text-stroke-color: #fff !important;
 }
 
 .vtt_style_background_25 .vtt_obj{
@@ -2171,6 +2173,15 @@ c.loader {
 .vtt_style_merienda{
   font-family: "Merienda", cursive, sans-serif;
   line-height: 1.2;
+}
+.vtt_style_medium_outline{
+  -webkit-text-stroke-width: 0.05vw !important;
+}
+.vtt_style_thick_outline{
+  -webkit-text-stroke-width: 0.1vw !important;
+}
+.vtt_style_extra_thick_outline{
+  -webkit-text-stroke-width: 0.15vw !important;
 }
 
 #pb_action_streamtype{

--- a/app/src/main/assets/view/m.js
+++ b/app/src/main/assets/view/m.js
@@ -4981,6 +4981,7 @@ const vtt={
     'Font Type',
     'Font Size',
     'Font Weight',
+    'Outline',
     'Background',
     'Color',
     'Text Opacity'
@@ -4989,6 +4990,7 @@ const vtt={
     'brand_family',
     'format_size',
     'format_bold',
+    'text_format',
     'gradient',
     'palette',
     'opacity'
@@ -5004,7 +5006,6 @@ const vtt={
       "Philosopher",
       "Reddit Sans",
       "Exo",
-
       "Merienda"
     ],
     [
@@ -5018,6 +5019,12 @@ const vtt={
       "Bold",
       "Bolder",
       "Thin"
+    ],
+    [
+      "Thin Outline",
+      "Medium Outline",
+      "Thick Outline",
+      "Extra Thick Outline",
     ],
     [
       "No Background",
@@ -5050,7 +5057,7 @@ const vtt={
     ],
   ],
   style_divs:[
-    1,10,100,1000,10000,100000
+    1,10,100,1000,10000,100000,1000000
   ],
   style_get:function(v, t, sl){
     if (t<0 || t>=vtt.style_order.length){


### PR DESCRIPTION
This PR adds a new subtitle style setting for "outline". The default "Thin Outline" setting reflects the current behavior. Thicker options use `-webkit-text-stroke-width`.

My main motivation for this is due do the current outline being far too thin for me personally. I typically watch on low brightness, so the thin outline on a bright background makes it hard to make out the text.

Feel free to close this PR or make suggestions if my approach is unwelcome. 